### PR TITLE
FEAT: add retrofit interface and connect to kaikas api

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,6 +42,9 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'com.google.android.material:material:1.11.0'
     implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0'
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+    implementation 'com.google.code.gson:gson:2.8.6'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,10 +4,15 @@
     tools:ignore="ExtraText">
 
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         tools:ignore="ScopedStorage" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.INTERNET" />
 
+    <queries>
+        <package android:name="io.klutch.wallet"/>
+    </queries>
 
     <application
         android:allowBackup="true"
@@ -18,7 +23,15 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.BICApplication"
+        android:usesCleartextTraffic="true"
         tools:targetApi="31">
+        <activity
+            android:name=".klaytn.Connect2KlaytnActivity"
+            android:exported="false">
+            <meta-data
+                android:name="android.app.lib_name"
+                android:value="" />
+        </activity>
         <activity
             android:name=".certify.CameraCertifyActivity"
             android:exported="false">
@@ -83,6 +96,7 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
             <meta-data
                 android:name="android.app.lib_name"
                 android:value="" />

--- a/app/src/main/java/com/example/bicapplication/LoginActivity.kt
+++ b/app/src/main/java/com/example/bicapplication/LoginActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import com.example.bicapplication.databinding.ActivityLoginBinding
+import com.example.bicapplication.klaytn.Connect2KlaytnActivity
 
 class LoginActivity : AppCompatActivity() {
     private lateinit var binding: ActivityLoginBinding
@@ -12,11 +13,10 @@ class LoginActivity : AppCompatActivity() {
         binding = ActivityLoginBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        //로그인 -> MainActivity로 이동
-        //추후 kaikas api 연동 필요
+        //로그인 -> Connect2Klaytn으로 이동
         binding.apply {
             imagebtnKaikasLogin.setOnClickListener {
-                val intent = Intent(this@LoginActivity, MainActivity::class.java)
+                val intent = Intent(this@LoginActivity, Connect2KlaytnActivity::class.java)
                 startActivity(intent)
             }
         }

--- a/app/src/main/java/com/example/bicapplication/klaytn/AuthData.kt
+++ b/app/src/main/java/com/example/bicapplication/klaytn/AuthData.kt
@@ -1,0 +1,11 @@
+package com.example.bicapplication.klaytn
+
+data class AuthData(
+    val type: String,
+    var bapp: Bapp,
+    val chain_id: String = "1001", // baobab testnet id
+) {
+    data class Bapp(
+        val name: String
+    )
+}

--- a/app/src/main/java/com/example/bicapplication/klaytn/Connect2KlaytnActivity.kt
+++ b/app/src/main/java/com/example/bicapplication/klaytn/Connect2KlaytnActivity.kt
@@ -1,0 +1,59 @@
+package com.example.bicapplication.klaytn
+
+import android.content.Intent
+import android.net.Uri
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.util.Log
+import com.example.bicapplication.databinding.ActivityConnect2KlaytnBinding
+import com.example.bicapplication.retrofit.RetrofitInterface
+import retrofit2.*
+
+class Connect2KlaytnActivity : AppCompatActivity() {
+    private lateinit var binding:ActivityConnect2KlaytnBinding
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityConnect2KlaytnBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        connect2kaikas()
+
+    }
+
+    private fun connect2kaikas() {
+        val reqAuth = AuthData("auth", AuthData.Bapp("BIC"))
+        val retrofitInterface = RetrofitInterface.create("https://api.kaikas.io/api/v1/k/")
+        var request_key = ""
+
+        //prepare - request - result
+        //retrofit 객체 만들어서 method 사용
+        retrofitInterface.requestAuth(reqAuth).enqueue(object : Callback<PrepareRespData> {
+            override fun onResponse(call: Call<PrepareRespData>, response: Response<PrepareRespData>){
+                //통신 성공했을 때
+                if(response.isSuccessful){
+                    Log.d("AUTH", "success auth ${response}")
+                    request_key = response.body()?.request_key.toString()
+                    request(request_key)
+                }
+                else{
+                    Log.d("AUTH", "success auth, but ${response.errorBody()}")
+                }
+            }
+            //통신 실패했을 때
+            override fun onFailure(call: Call<PrepareRespData>, t: Throwable) {
+                Log.d("AUTH", "fail ${t}")
+            }
+
+        })
+    }
+
+    //deeplink to kaikas app
+    private fun request(reqkey:String) {
+        try {
+            val uri = Uri.parse("kaikas://wallet/api?request_key=${reqkey}")
+            startActivity(Intent(Intent.ACTION_VIEW, uri))
+        } catch (e:Exception){
+            Log.d("REQUEST", "fail to request. ${e}")
+        }
+    }
+
+}

--- a/app/src/main/java/com/example/bicapplication/klaytn/PrepareRespData.kt
+++ b/app/src/main/java/com/example/bicapplication/klaytn/PrepareRespData.kt
@@ -1,0 +1,8 @@
+package com.example.bicapplication.klaytn
+
+data class PrepareRespData(
+    val chain_id: String,
+    val request_key: String,
+    val status: String,
+    val expiration_time: Int
+)

--- a/app/src/main/java/com/example/bicapplication/klaytn/ResultRespData.kt
+++ b/app/src/main/java/com/example/bicapplication/klaytn/ResultRespData.kt
@@ -1,0 +1,17 @@
+package com.example.bicapplication.klaytn
+
+data class ResultRespData(
+    val expiration_time: Int,
+    val request_key: String,
+    val result: Result,
+    val status: String,
+    val type: String,
+    val chain_id: String = "1001", //baobab testnet id
+    val code: Int = 0,
+    val message: Any? = null
+) {
+    data class Result(
+        val signed_tx: String,
+        val tx_hash: String
+    )
+}

--- a/app/src/main/java/com/example/bicapplication/retrofit/RetrofitInterface.kt
+++ b/app/src/main/java/com/example/bicapplication/retrofit/RetrofitInterface.kt
@@ -1,0 +1,54 @@
+package com.example.bicapplication.retrofit
+
+import com.example.bicapplication.klaytn.AuthData
+import com.example.bicapplication.klaytn.PrepareRespData
+import com.example.bicapplication.klaytn.ResultRespData
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.*
+
+interface RetrofitInterface {
+    //Retrofit 객체. 메모리 낭비 방지를 위해 singleton
+    companion object RetrofitObject {
+        //retrofit 객체 만들어서 사용할 때, 인자로 baseURL 넘겨주면 됨
+        fun create(baseURL: String): RetrofitInterface {
+            val gson:Gson = GsonBuilder().setLenient().create()
+
+            return Retrofit.Builder()
+                .baseUrl(baseURL)
+                .addConverterFactory(GsonConverterFactory.create(gson))
+                .build()
+                .create(RetrofitInterface::class.java)
+        }
+    }
+
+    //kaikas method
+    //kaikas prepare-Auth step method
+    @Headers("Content-Type: application/json;charset=utf-8")
+    @POST("prepare")
+    fun requestAuth(
+        @Body authinfo: AuthData
+    ) : Call<PrepareRespData>
+
+    //kaikas result step method
+    @Headers("Content-Type: application/json;charset=utf-8")
+    @GET("result/{request_key}")
+    fun requestResult(
+        @Path("request_key") request_key:String
+    ) : Call<ResultRespData>
+
+
+    // 유경 method
+
+
+
+
+
+
+
+
+    // 민우 method
+}

--- a/app/src/main/res/layout/activity_connect2_klaytn.xml
+++ b/app/src/main/res/layout/activity_connect2_klaytn.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".klaytn.Connect2KlaytnActivity">
+
+    <WebView
+        android:id="@+id/webview_connect2klaytn"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 개요
- Retrofit 구현
- Kaikas API 통신 일부 구현
- 딥링크 구현 관련 사항 추가

## 작업 사항
- HTTP 통신을 위한 Retrofit Interface&Object 구현
    - dependencies 추가
    - 메모리를 위해 companion object 사용
    - RetrofitInterface 사용 시, "create" 함수의 인자로 baseurl 넘겨줘서 object 자유롭게 사용 가능하도록 구현해둠
- Kaikas 로그인 연동 과정 3단계 중 (1)prepare, (3)result 단계 구현
- 딥링크 구현 관련 사항 추가
    - WebView 포함한 액티비티 추가
    - LoginActivity 버튼 클릭 이벤트 동작 변경
    - kaikas 딥링크를 위한 manifest.xml queries 추가

## 추후 계획
- Kaikas (2)request 구현 및 API 통신 과정 마무리
    - kaikas 연결을 위한 딥링크 구현 -> 웹뷰 연결