### PR TITLE
feat: creat githubId Dialog & repo url

### DIFF
--- a/app/src/main/java/com/example/bicapplication/LoginActivity.kt
+++ b/app/src/main/java/com/example/bicapplication/LoginActivity.kt
@@ -23,7 +23,7 @@ class LoginActivity : AppCompatActivity() {
         //로그인 -> Connect2Klaytn으로 이동
         binding.apply {
             imagebtnKaikasLogin.setOnClickListener {
-                val intent = Intent(this@LoginActivity, Connect2KlaytnActivity::class.java) ///MainActivity
+                val intent = Intent(this@LoginActivity, MainActivity::class.java) ///MainActivity
                 startActivity(intent)  //Connect2KlaytnActivity
                 //finish()
             }

--- a/app/src/main/java/com/example/bicapplication/MainActivity.kt
+++ b/app/src/main/java/com/example/bicapplication/MainActivity.kt
@@ -3,6 +3,9 @@ package com.example.bicapplication
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.MenuItem
+import android.widget.EditText
+import androidx.appcompat.app.AlertDialog
+import androidx.core.view.marginStart
 import com.example.bicapplication.databinding.ActivityMainBinding
 import com.example.bicapplication.mychall.MychallFragment
 import com.google.android.material.navigation.NavigationBarView
@@ -26,6 +29,8 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
         supportFragmentManager.beginTransaction()
             .replace(R.id.main_frame, homeFragment).commit()
 
+        //로컬에 저장된 유저정보가 없으면 깃허브id 입력받고 로컬db, 몽고db에 저장
+        githubDialog()
     }
 
     override fun onNavigationItemSelected(item: MenuItem): Boolean {
@@ -57,5 +62,28 @@ class MainActivity : AppCompatActivity(), NavigationBarView.OnItemSelectedListen
         }
 
         return true
+    }
+
+
+    //깃허브id 입력받고 저장
+    private fun githubDialog(){
+        val builder = AlertDialog.Builder(this)
+        builder.setMessage("본인 깃허브 ID를 입력해주세요.")
+        builder.setCancelable(false) // 다이얼로그 화면 밖 터치 방지
+        val editText = EditText(this)
+        builder.setView(editText)
+
+        builder.setPositiveButton(
+            "완료"
+        ) { dialog, which ->
+        //로컬db와 몽고db에 저장해주는 로직 진행
+
+        }
+        builder.setNeutralButton(
+            "다음에 하기"
+        ) { dialog, which ->
+        }
+
+        builder.show() // 다이얼로그 보이기
     }
 }

--- a/app/src/main/java/com/example/bicapplication/certify/CertifyStatusActivity.kt
+++ b/app/src/main/java/com/example/bicapplication/certify/CertifyStatusActivity.kt
@@ -34,7 +34,7 @@ class CertifyStatusActivity : AppCompatActivity() {
 
         //인증하기 버튼 클릭시 -> 액션, 깃허브, 이미지 인증 3개중 한개 페이지 이동
         binding.certifyButton.setOnClickListener {
-            val intent = Intent(this, CameraCertifyActivity::class.java)  //ActionCertifyActivity  //GithubCertifyActivity  //CameraCertifyActivity
+            val intent = Intent(this, GithubCertifyActivity::class.java)  //ActionCertifyActivity  //GithubCertifyActivity  //CameraCertifyActivity
             startActivity(intent)
             finish()
         }
@@ -93,7 +93,7 @@ class CertifyStatusActivity : AppCompatActivity() {
             Log.e("태그,", "commitRepo:"+commitRepo)
 
             val success = if (is_success) "인증완료" else "미인증"
-            binding.successTextView.text = "$success\n커밋날짜: $commitDate\n레포이름: $commitRepo"
+            binding.successTextView.text = "$success\n커밋 날짜: $commitDate\n커밋한 레포: $commitRepo\n레포URL: https://github.com/로컬에 저장된 유저깃허브id값 넣기/$commitRepo "
         }
     }
 

--- a/app/src/main/java/com/example/bicapplication/certify/GithubCertifyActivity.kt
+++ b/app/src/main/java/com/example/bicapplication/certify/GithubCertifyActivity.kt
@@ -64,7 +64,7 @@ class GithubCertifyActivity : AppCompatActivity() {
                     Log.e("태그", "깃허브커밋 통신 성공, "+response.body() )
 //                    Toast.makeText(this@GithubCertifyActivity, "인증결과: "+response.body()?.is_committed
 //                        +"\n마지막 커밋날짜:"+response.body()?.lastcommitday +"\n커밋한 repo이름:"+ response.body()?.commitRepo , Toast.LENGTH_SHORT).show()
-                    Toast.makeText(this@GithubCertifyActivity, "커밋한 repo이름:"+ response.body()?.commitRepo , Toast.LENGTH_SHORT).show()
+                    //Toast.makeText(this@GithubCertifyActivity, "인증성패여부", Toast.LENGTH_SHORT).show()
                     is_success = response.body()?.is_committed!!  //성공여부 저장
                     commitDate = response.body()?.lastcommitday!! //최신 커밋날짜 저장
                     commitRepo = response.body()?.commitRepo!! //커밋한 레포 저장

--- a/app/src/main/res/layout/activity_certify_status.xml
+++ b/app/src/main/res/layout/activity_certify_status.xml
@@ -92,7 +92,7 @@
                 android:id="@+id/gridView"
                 android:layout_width="0dp"
                 android:layout_height="500dp"
-                android:layout_marginTop="100dp"
+                android:layout_marginTop="130dp"
                 android:numColumns="2"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.0"


### PR DESCRIPTION
1. 로그인 후 메인액티비티 실행시 깃허브id입력 다이얼로그 실행 (로컬db와 몽고db 저장 작업 진행전)
2. 깃허브 인증 성공시 레포 url값 인증화면에 띄움 