### PR TITLE
Feat/certify detail

### DIFF
--- a/app/src/main/java/com/example/bicapplication/GlobalVari.kt
+++ b/app/src/main/java/com/example/bicapplication/GlobalVari.kt
@@ -4,7 +4,7 @@ package com.example.bicapplication
 class GlobalVari{
     //GlobalVari 클래스의 모든 객체가 함께 공유하는 baseurl 변수
     companion object {
-        private var baseurl:String = "http://10.0.2.2:8081/"
+        private var baseurl:String = "http://192.168.0.104:8081/"    //192.168.0.104
         fun getUrl() : String{
             return baseurl
         }

--- a/app/src/main/java/com/example/bicapplication/certify/CameraCertifyActivity.kt
+++ b/app/src/main/java/com/example/bicapplication/certify/CameraCertifyActivity.kt
@@ -38,7 +38,7 @@ class CameraCertifyActivity : AppCompatActivity() {
             val intent = Intent(this, CertifyStatusActivity::class.java)
             intent.putExtra("사진", bitmap)
             intent.putExtra("이미지인증방문", true)
-            startActivity(intent)
+            setResult(1,intent)
             finish()
         }
     }

--- a/app/src/main/java/com/example/bicapplication/certify/CertifyStatusActivity.kt
+++ b/app/src/main/java/com/example/bicapplication/certify/CertifyStatusActivity.kt
@@ -3,13 +3,21 @@ package com.example.bicapplication.certify
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.graphics.Bitmap
-import android.opengl.Visibility
 import android.os.Bundle
 import android.util.Log
 import android.view.View
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.datastore.dataStore
+import com.example.bicapplication.GlobalVari
 import com.example.bicapplication.R
 import com.example.bicapplication.databinding.ActivityCertifyStatusBinding
+import com.example.bicapplication.manager.DataStoreModule
+import com.example.bicapplication.retrofit.RetrofitInterface
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
 
 
 //진행중인 챌린지의 인증현황을 보여주는 액티비티
@@ -18,105 +26,155 @@ class CertifyStatusActivity : AppCompatActivity() {
     private lateinit var binding: ActivityCertifyStatusBinding
     private var adapter: CertifyStatusAdapter? = null
     private var certifyDataList: Array<CertifyData>? = null
+    private lateinit var challId: String
+    private lateinit var endDate: String
 
+    //인증화면(이미지, 액션, 깃허브) 갔다올때 성공여부 등 데이터 전달받기위함
+    private val activityResultLauncher: ActivityResultLauncher<Intent> = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) {
+
+        /**
+        이미지인증 결과 받아옴
+         */
+        if (it.resultCode == 1) {
+            val intent = it.data
+            val bitmap = intent?.getParcelableExtra<Bitmap>("사진")
+            val visited = intent?.getBooleanExtra("이미지인증방문", false) //이미지인증을 갔다온건지 확인위함
+            binding.imageView.visibility = View.GONE
+            //이미지 인증을 갔다왔으면 진행
+            if (visited == true) {
+                Log.e("태그,", "bitmap:" + bitmap)
+                if (bitmap != null) {  //올린 사진이 있을경우(인증 완료인 경우)
+                    binding.imageView.visibility = View.VISIBLE
+                    binding.imageView.setImageBitmap(bitmap)
+                    binding.successTextView.visibility = View.GONE
+                } else {  //아직 이미지 인증 안했거나, 다른 인증인 경우
+                    binding.imageView.visibility = View.GONE
+                }
+            }
+        }
+
+        /**
+        액션인증 결과 받아옴
+         */
+        else if (it.resultCode == 2) {
+            val intent = it.data
+            val visited = intent?.getBooleanExtra("액션인증방문", false) //깃허브인증을 갔다온건지 확인위함
+            val is_success = intent?.getBooleanExtra("성공여부", false)
+
+            //액션 인증 갔다가 여기로 온거라면 진행
+            if (visited == true) {
+                Log.e("태그,", "is_success:" + is_success)
+
+                var success = ""
+                if (is_success == true) {
+                    success = "성공"
+                    //DB의 activiated_chall에 해당 유저의 is_sucesss필드에다가 성공횟수 +1 하기
+                    plusSuccessCount()
+
+                } else {
+                    success = "실패"
+
+                }
+                binding.successTextView.text = success
+            }
+        }
+
+        /**
+        깃허브인증 결과 받아옴
+         */
+        else if (it.resultCode == 3) {
+            val intent = it.data
+            val visited = intent?.getBooleanExtra("깃허브인증방문", false) //깃허브인증을 갔다온건지 확인위함
+            val is_success = intent?.getBooleanExtra("성공여부", false)
+            val commitDate = intent?.getStringExtra("커밋날짜")
+            val commitRepo = intent?.getStringExtra("커밋레포")
+
+            //깃허브 인증 갔다가 여기로 온거라면 진행
+            if (visited == true) {
+                var success = ""
+                if (is_success == true) {
+                    success = "성공"
+                    //DB의 activiated_chall에 해당 유저의 is_sucesss필드에다가 성공횟수 +1 하기
+                } else {
+                    success = "실패"
+
+
+                }
+                binding.imageView.visibility = View.GONE
+                binding.successTextView.text =
+                    "$success\n최신 커밋 날짜: $commitDate\n커밋한 레포: $commitRepo\n레포URL: https://github.com/로컬에 저장된 유저깃허브id값 넣기/$commitRepo "
+            }
+        }
+    }
+
+
+    @SuppressLint("SetTextI18n")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityCertifyStatusBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        //mychall프래그먼트로부터 전달 받은 챌id와 종료기간
+        val intent = intent
+        challId = intent.getStringExtra("challId").toString()
+        endDate = intent.getStringExtra("endDate").toString()
+
+        binding.TimeTextView.text = "종료 시간:$endDate"
+
         certifyDataList = arrayOf(
             CertifyData("aa", R.drawable.bic_logo),
-            CertifyData("bb",R.drawable.bic_logo),
-            CertifyData("cc",R.drawable.bic_logo),
-            CertifyData("dd",R.drawable.bic_logo),
-            CertifyData("ee",R.drawable.bic_logo)
+            CertifyData("bb", R.drawable.bic_logo),
+            CertifyData("cc", R.drawable.bic_logo),
+            CertifyData("dd", R.drawable.bic_logo),
+            CertifyData("ee", R.drawable.bic_logo)
         )
+
 
         //인증하기 버튼 클릭시 -> 액션, 깃허브, 이미지 인증 3개중 한개 페이지 이동
         binding.certifyButton.setOnClickListener {
-            val intent = Intent(this, GithubCertifyActivity::class.java)  //ActionCertifyActivity  //GithubCertifyActivity  //CameraCertifyActivity
-            startActivity(intent)
-            finish()
+            val intent = Intent(
+                this,
+                ActionCertifyActivity::class.java
+            )  //ActionCertifyActivity  //GithubCertifyActivity  //CameraCertifyActivity
+            activityResultLauncher.launch(intent)
         }
-
-        // 1.이미지 인증 액티비티(cameraCertifyActivity)로부터 내가 찍은 사진 받아와서 뷰에 보여줌
-        getMyPicture()
-
-        // 2.깃허브 인증 액티비티로부터 받아온 깃허브 크롤링 결과값 받아와서 뷰에 보여줌
-        getMyGithub()
-
-        // 3.액션 인증 액티비티로부터 받아온 성공여부 결과값 받아와서 뷰에 보여줌
-        getActionResult()
 
         adapter = CertifyStatusAdapter(this, certifyDataList)
         binding.gridView.adapter = adapter
     }
 
 
-    /**
-    이미지 인증 관련 메소드
-     */
-    //여기에 나중에 db로부터 인증 이미지들 가져올때 만약 이미지 존재하면 그 값등으로 바꾸기
-    private fun getMyPicture(){
-        val intent = intent  //이미지 인증 액티비티를 마친 후 전달받은 데이터
-        val bitmap = intent.getParcelableExtra<Bitmap>("사진")
-        val visited = intent.getBooleanExtra("이미지인증방문",false) //이미지인증을 갔다온건지 확인위함
-        binding.imageView.visibility = View.GONE
-
-        if(visited){    //이미지 인증을 갔다왔으면 진행
-            Log.e("태그,", "bitmap:"+bitmap)
-            if(bitmap!=null){
-                binding.imageView.visibility = View.VISIBLE
-                binding.imageView.setImageBitmap(bitmap)
-            }else{  //아직 이미지 인증 안했거나, 다른 인증인 경우
-                //binding.imageView.visibility = View.GONE
+    //챌린지 인증 성공시 DB의 성공횟수 1증가 로직
+    private fun plusSuccessCount() {
+        val userid = "65b537f388bb8423ff6e0f8d"//현재는 임의설정. 이후엔 datastore값 이용 예정
+        //Log.e("태그", "userid: " + userid)
+        val retrofitInterface = RetrofitInterface.create(GlobalVari.getUrl())
+        retrofitInterface.putSuccess(userid, challId).enqueue(object : Callback<String> {
+            override fun onFailure(
+                call: Call<String>,
+                t: Throwable
+            ) {
+                Log.e("태그", "통신 아예실패  ,t.message: " + t.message)
             }
-        }
+
+            override fun onResponse(
+                call: Call<String>,
+                response: Response<String>
+            ) {
+                if (response.isSuccessful) {
+                    Log.e("태그", "성공횟수 증가 통신 성공: , response.body():" + response.body())
+                    Log.e("태그", "challId: $challId")
+
+                } else {
+                    Log.e(
+                        "태그",
+                        "서버접근했지만 실패: response.errorBody()?.string()" + response.errorBody()
+                            .toString()
+                    )
+                }
+            }
+        })
     }
-
-    /**
-    깃허브 인증 관련 메소드
-     */
-    //여기에 나중에 db로부터 깃허브 인증 가져올때 존재하면 그 값으로 등 바꾸기
-    @SuppressLint("SetTextI18n")
-    private fun getMyGithub(){
-        val intent = intent  //깃허브 인증 액티비티 마친 후 전달받은 데이터
-        val visited = intent.getBooleanExtra("깃허브인증방문",false) //깃허브인증을 갔다온건지 확인위함
-        val is_success = intent.getBooleanExtra("성공여부",false)
-        val commitDate = intent.getStringExtra("커밋날짜")
-        val commitRepo = intent.getStringExtra("커밋레포")
-
-        //깃허브 인증 갔다가 여기로 온거라면 진행
-        if(visited){
-            Log.e("태그,", "is_success:"+is_success)
-            Log.e("태그,", "commitDate:"+commitDate)
-            Log.e("태그,", "commitRepo:"+commitRepo)
-
-            val success = if (is_success) "인증완료" else "미인증"
-            binding.successTextView.text = "$success\n커밋 날짜: $commitDate\n커밋한 레포: $commitRepo\n레포URL: https://github.com/로컬에 저장된 유저깃허브id값 넣기/$commitRepo "
-        }
-    }
-
-    /**
-    액션 인증 관련 메소드
-     */
-    //여기에 나중에 db로부터 깃허브 인증 가져올때 존재하면 그 값으로 등 바꾸기
-    @SuppressLint("SetTextI18n")
-    private fun getActionResult(){
-        val intent = intent  //깃허브 인증 액티비티 마친 후 전달받은 데이터
-        val visited = intent.getBooleanExtra("액션인증방문",false) //깃허브인증을 갔다온건지 확인위함
-        val is_success = intent.getBooleanExtra("성공여부",false)
-
-        //깃허브 인증 갔다가 여기로 온거라면 진행
-        if(visited){
-            Log.e("태그,", "is_success:"+is_success)
-
-            val success = if (is_success) "성공" else "실패"
-            binding.successTextView.text = success
-        }
-    }
-
-
-
-
 }

--- a/app/src/main/java/com/example/bicapplication/certify/GithubCertifyActivity.kt
+++ b/app/src/main/java/com/example/bicapplication/certify/GithubCertifyActivity.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
+import com.example.bicapplication.GlobalVari
 import com.example.bicapplication.R
 import com.example.bicapplication.databinding.ActivityActionCertifyBinding
 import com.example.bicapplication.databinding.ActivityGithubCertifyBinding
@@ -46,7 +47,7 @@ class GithubCertifyActivity : AppCompatActivity() {
 
     //서버로부터 깃허브 커밋여부와 마지막 커밋날짜 가져옴
     private fun getMyCommitInfo(githubId : String){
-        val retrofitInterface = RetrofitInterface.create("http://10.0.2.2:8081/")
+        val retrofitInterface = RetrofitInterface.create(GlobalVari.getUrl())
         retrofitInterface.getIsCommitted(githubId).enqueue(object : Callback<BooleanResponse> {
             override fun onFailure(
                 call: Call<BooleanResponse>,
@@ -87,7 +88,7 @@ class GithubCertifyActivity : AppCompatActivity() {
         intent.putExtra("커밋날짜", commitDate)
         intent.putExtra("커밋레포", commitRepo)
         intent.putExtra("깃허브인증방문", true)
-        startActivity(intent)
+        setResult(3,intent)
         finish()
     }
 

--- a/app/src/main/java/com/example/bicapplication/mychall/Challenge.kt
+++ b/app/src/main/java/com/example/bicapplication/mychall/Challenge.kt
@@ -1,4 +1,4 @@
 package com.example.bicapplication.mychall
 
-//챌린지 하나의 정보 담고있는 객체 (챌린지 제목, 인증방식, 참여자수, 만료기간 )
-data class Challenge(var stack: String, var title: String, var certifyMethod: String, var number: String, var period:String )
+//챌린지 하나의 정보 담고있는 객체 (챌린지 id, 챌린지 제목, 인증방식, 참여자수, 만료기간 )
+data class Challenge(var id:String, var stack: String, var title: String, var certifyMethod: String, var number: String, var period:String )

--- a/app/src/main/java/com/example/bicapplication/mychall/MychallAdapter.kt
+++ b/app/src/main/java/com/example/bicapplication/mychall/MychallAdapter.kt
@@ -38,7 +38,7 @@ class MychallAdapter(
         view?.findViewById<TextView>(R.id.numberTextView)?.text = item?.number //참여자수
         view?.findViewById<TextView>(R.id.periodTextView)?.text = item?.period //만료기간
 
-        //그리드뷰의 챌린지뷰 하나 클릭시 인증페이지 이동
+        //그리드뷰의 챌린지뷰 하나 클릭시 인증페이지 이동 (챌린지 id, 챌린지 종료기간 데이터 전송)
         view?.setOnClickListener {
             val intent = Intent(context, CertifyStatusActivity::class.java)
             context?.startActivity(intent)

--- a/app/src/main/java/com/example/bicapplication/mychall/MychallFragment.kt
+++ b/app/src/main/java/com/example/bicapplication/mychall/MychallFragment.kt
@@ -66,12 +66,14 @@ class MychallFragment : Fragment() {
                         challDataArray.add(challData)
                     }
 
-                    // 챌린지 클릭 시 인증페이지로 이동
+                    //챌린지 클릭시 해당 챌의 id값과 종료기간 인증act로 전달 및 이동
                     adapter = ChallListAdapter(challDataArray) {
-                        SelectedchallActivity.challData = it
                         val intent = Intent(activity, CertifyStatusActivity::class.java)
+                        intent.putExtra("challId", it.challId)
+                        intent.putExtra("endDate", it.enddate)
                         startActivity(intent)
                     }
+
                     binding.mychallRecyclerview.adapter = adapter
 
                 }
@@ -86,14 +88,6 @@ class MychallFragment : Fragment() {
             }
         })
 
-
-        /*
-        //인증현황페이지 테스트 위한 작업
-        binding.mychall.setOnClickListener {
-            val intent = Intent(activity, CertifyStatusActivity::class.java)
-            startActivity(intent)
-        }
-         */
 
         return binding.root
     }

--- a/app/src/main/java/com/example/bicapplication/retrofit/RetrofitInterface.kt
+++ b/app/src/main/java/com/example/bicapplication/retrofit/RetrofitInterface.kt
@@ -7,6 +7,7 @@ import com.example.bicapplication.responseObject.ListResponseData
 import com.example.bicapplication.responseObject.UserPostResponse
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
+import kotlinx.coroutines.flow.Flow
 import retrofit2.Call
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -149,6 +150,13 @@ interface RetrofitInterface {
     //신규 유저 등록 요청
     @POST("user/add")
     fun postUser(@Body users: UserData): Call<UserPostResponse>
+
+    //챌린지 인증 성공해서 db에 성공횟수 증 요청
+    @PUT("success/{userId}/{challId}")
+    fun putSuccess(@Path("userId") userId: String, @Path("challId") challId:String): Call<String>
+
+
+
 
 
 }


### PR DESCRIPTION
# 개요

-  인증 관련 추가, 수정 


# 작업사항

-  챌린지 종료기간 인증화면 상단에 띄워주기
- 액션인증 오답시 기회 추가 2번 더 부여 (횟수 수정 가능)
- 인증 성공시 DB에 성공횟수 저장

# 이후 작업

- 인증현황 화면에 각 참가자들의 이름 및 성공횟수 표기

